### PR TITLE
Add missing dependency

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -19,29 +19,8 @@ all	: dir $(TESTS) $(MPI_TESTS)
 dir	:
 		mkdir -p $(BIN)
 
-testAll		: testAll.c
-		$(CC) $^ -o $(BIN)/$@ $(CFLAGS) $(CPPFLAGS) $(INC) $(LIB)
-
-testState	: testState.c
-		$(CC) $^ -o $(BIN)/$@ $(CFLAGS) $(CPPFLAGS) $(INC) $(LIB)
-
-testState_parall	: testState_parall.c
-		$(CC) $^ -o $(BIN)/$@ $(CFLAGS) $(CPPFLAGS) $(INC) $(LIB)
-
-testEvent_parall	: testEvent_parall.c
-		$(CC) $^ -o $(BIN)/$@ $(CFLAGS) $(CPPFLAGS) $(INC) $(LIB)
-
-testEvent_mpi	: testEvent_mpi.c
-		$(CC) $^ -o $(BIN)/$@ $(CFLAGS) $(CPPFLAGS) $(INC) $(LIB)
-
-testEvent	: testEvent.c
-		$(CC) $^ -o $(BIN)/$@ $(CFLAGS) $(CPPFLAGS) $(INC) $(LIB)
-
-testLink	: testLink.c
-		$(CC) $^ -o $(BIN)/$@ $(CFLAGS) $(CPPFLAGS) $(INC) $(LIB)
-
-testVar		: testVar.c
-		$(CC) $^ -o $(BIN)/$@ $(CFLAGS) $(CPPFLAGS) $(INC) $(LIB)
+%		: %.c dir
+		$(CC) $< -o $(BIN)/$@ $(CFLAGS) $(CPPFLAGS) $(INC) $(LIB)
 
 check   : all
 	for i in $(TESTS) ; do \


### PR DESCRIPTION
test targets need $(BIN) being created first.

while at it, just factorize the rules.