### PR TITLE
Add missing dependency

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -22,6 +22,7 @@ $(DOX_TAG): $(docx_inputs)
 	touch $(DOX_TAG)
 
 $(DOX_HTML_DIR): $(DOX_TAG)
+$(DOX_HTML_DIR)/index.html: $(DOX_HTML_DIR)
 
 $(DOX_PDF): $(DOX_TAG)
 	cd $(DOX_LATEX_DIR) &&\


### PR DESCRIPTION
When running make --shuffle=reverse install, we otherwise get

make[3]: *** No rule to make target 'html//index.html', needed by 'install_html'.  Stop.