### PR TITLE
allow to initTrace() again after endTrace().

### DIFF
--- a/src/C/paje_GTGBasic1_c.c
+++ b/src/C/paje_GTGBasic1_c.c
@@ -922,6 +922,7 @@ __pajeEndTrace_generic (int should_merge) {
   if (filename)
     free (filename);
   filename = NULL;
+  _is_paje_header_written = 0;
   return TRACE_SUCCESS;
 }
 


### PR DESCRIPTION
This patch allows to call initTrace() again after endTrace(), so as to generate multiple PAJE traces in a row from the same process.